### PR TITLE
Update spidev.c increase default bufsiz to 32767

### DIFF
--- a/linux_5.10/drivers/spi/spidev.c
+++ b/linux_5.10/drivers/spi/spidev.c
@@ -82,7 +82,7 @@ struct spidev_data {
 static LIST_HEAD(device_list);
 static DEFINE_MUTEX(device_list_lock);
 
-static unsigned bufsiz = 4096;
+static unsigned bufsiz = 32767;
 module_param(bufsiz, uint, S_IRUGO);
 MODULE_PARM_DESC(bufsiz, "data bytes in biggest supported SPI message");
 


### PR DESCRIPTION
Increase default
static unsigned bufsiz = 4096;
to
static unsigned bufsiz = 32767;